### PR TITLE
fix `asdf list-all dmd` only shows oldest version

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -1,26 +1,12 @@
 #!/usr/bin/env bash
 
-# Based on the list-all script from elixir
-# https://github.com/asdf-vm/asdf-elixir/blob/master/bin/list-all
+# Based on the list-all script from asdf-direnv
+# https://github.com/asdf-community/asdf-direnv/blob/master/bin/list-all
 
-# Download the list of tags from github's API.
-#
-# The DMD repository returns an empty array for releases, so we use tags
-# instead.
-download_dmd_tags() {
-    local tags_url="https://api.github.com/repos/dlang/dmd/tags?per_page=100"
-    if ! curl -Lfs "$tags_url"; then
-        cat >&2 <<EOS
-==> Failed to fetch DMD tags from api.github.com
-
-Make sure your internet connection is stable and
-that you can reach:
-${tags_url}
-
-EOS
-
-        return 1
-    fi
+# List version tags in the DMD repository.
+list_dmd_tags() {
+    git ls-remote --tags --refs https://github.com/dlang/dmd.git |
+        sed -n '/v1\.\|-rc\|-b\|beta/!s,.*refs/tags/v,,p'
 }
 
 # Sort the list of tags
@@ -63,12 +49,5 @@ sort_tags() {
     LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n
 }
 
-# Extract only releases that are not beta or rc.
-#
-# Line numbers need to be removed from the grep result.
-extract_version_numbers() {
-    versions=$(grep -oE "name\": \"v2\..{1,6}\"," | sed 's/name\": \"v//;s/\",//;s/-b.*$//;s/-rc.*$//;s/beta.*$//' | uniq)
-    echo "$versions"
-}
-
-download_dmd_tags | extract_version_numbers | sort_tags
+versions="$(list_dmd_tags | sort_tags)"
+echo $versions


### PR DESCRIPTION
I used `git ls-remote` because the GitHub API has strict rate limits.

```sh
# master
$ asdf list-all dmd
2.089.0

# PR
$ asdf list-all dmd
2.054
2.055
2.056
2.057
2.058
2.059
2.060
2.061
2.062
2.063
2.063.1
2.063.2
2.064
2.064.2
2.065.0
2.066.0
2.066.1
2.067.0
2.067.1
...
```